### PR TITLE
fix: remove terminal dots from individual stat cards for cleaner design

### DIFF
--- a/src/components/EnhancedStatsSection.tsx
+++ b/src/components/EnhancedStatsSection.tsx
@@ -121,18 +121,8 @@ export default function EnhancedStatsSection(): JSX.Element {
               }`}
               style={{ animationDelay: `${index * 150}ms` }}
             >
-              {/* Terminal Header */}
-              <div className="mb-4 flex items-center space-x-2 border-b border-card-border pb-3">
-                <div className="h-2 w-2 rounded-full bg-red-400"></div>
-                <div className="h-2 w-2 rounded-full bg-yellow-400"></div>
-                <div className="h-2 w-2 rounded-full bg-green-400"></div>
-                <span className="ml-2 font-mono text-xs text-muted">
-                  stats.sh
-                </span>
-              </div>
-
               {/* Terminal Content */}
-              <div className="space-y-3 font-mono text-sm">
+              <div className="space-y-3 p-4 font-mono text-sm">
                 {/* Command */}
                 <div className="text-muted">
                   <span className="text-accent">$</span>


### PR DESCRIPTION
## 🐛 Bug Fix: Stats Cards Terminal Dots

### Problem
The individual stat cards in the `EnhancedStatsSection` component were displaying red, yellow, green terminal dots, making them appear as separate terminal windows rather than being part of a unified stats section.

### Solution
- **Removed terminal dots** from individual stat cards
- **Added proper padding** (`p-4`) to maintain visual spacing
- **Preserved terminal aesthetic** for the main section header only

### Before
Each stat card had its own terminal window decoration:
```
🔴 🟡 🟢 stats.sh
$ command
output
```

### After
Clean, unified stats cards without individual terminal decorations:
```
$ command
output
```

### Design Rationale
- **Main section header** (Professional Achievements) retains terminal dots as it represents a terminal window
- **Individual stat cards** are now clean data displays without competing visual elements
- **Better visual hierarchy** - stats are clearly part of a unified section
- **Improved readability** - less visual noise, more focus on the metrics

### Files Changed
- `src/components/EnhancedStatsSection.tsx`: Removed terminal header from individual stat cards

### Testing
- ✅ Linter passes (only pre-existing warnings)
- ✅ TypeScript compilation successful
- ✅ Visual design is cleaner and more professional
- ✅ Maintains terminal aesthetic where appropriate

This fix improves the overall design consistency and makes the stats section more visually appealing and easier to read.